### PR TITLE
Use public Danger-Shroud.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 source "https://rubygems.org"
 gem 'danger'
-gem 'danger-shroud', git: 'https://github.com/livefront/livefront-shroud-android/'
+gem 'danger-shroud'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,3 @@
-GIT
-  remote: https://github.com/livefront/livefront-shroud-android/
-  revision: 1e0185efdd8e99c003e9a41bf0114dd826e1638c
-  specs:
-    danger-shroud (0.0.1)
-      danger-plugin-api (~> 1.0)
-      nokogiri
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -19,7 +11,7 @@ GEM
     colored2 (3.1.2)
     cork (0.3.0)
       colored2 (~> 3.1)
-    danger (6.3.1)
+    danger (6.3.2)
       claide (~> 1.0)
       claide-plugins (>= 0.9.2)
       colored2 (~> 3.1)
@@ -34,6 +26,9 @@ GEM
       terminal-table (~> 1)
     danger-plugin-api (1.0.0)
       danger (> 2.0)
+    danger-shroud (0.0.1)
+      danger-plugin-api (~> 1.0)
+      nokogiri
     faraday (0.17.3)
       multipart-post (>= 1.2, < 3)
     faraday-http-cache (2.0.0)
@@ -49,7 +44,7 @@ GEM
     no_proxy_fix (0.1.2)
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
-    octokit (4.17.0)
+    octokit (4.18.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
     open4 (1.3.4)
@@ -67,7 +62,7 @@ PLATFORMS
 
 DEPENDENCIES
   danger
-  danger-shroud!
+  danger-shroud
 
 BUNDLED WITH
    2.1.4


### PR DESCRIPTION
This PR updates the project to use the public version of Danger-Shroud.