### PR TITLE
Add the maven plugin for use with JitPack.

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'kotlin'
+apply plugin: 'maven'
 
 apply from: rootProject.file("gradle/jacoco.gradle")
 


### PR DESCRIPTION
This MR adds the `maven` plugin to the build script allowing the library to be published to JitPack.