### PR TITLE
Update for sealed classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Change Log
 Ensure that access to the constructor is available allowing private constructors to be used
 When `enableDefaultPrimitiveValues` is set, always treat primitives as though they have a default value
 Only fetch the delegate adapter when the property is going to be serialized/deserialized
+Move checks for `isSealed` and `isAbstract` from `create` to `read` since Gson will still serialize the data, even if we cannot deserialize it
 
 # 0.2.0
 Allow use to optionally use default primitive values when missing from JSON

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Change Log
 # Next Release
 Ensure that access to the constructor is available allowing private constructors to be used
 When `enableDefaultPrimitiveValues` is set, always treat primitives as though they have a default value
+Only fetch the delegate adapter when the property is going to be serialized/deserialized
 
 # 0.2.0
 Allow use to optionally use default primitive values when missing from JSON

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Change Log
 ==========
 
 # Next Release
+Ensure that access to the constructor is available allowing private constructors to be used
 
 # 0.2.0
 Allow use to optionally use default primitive values when missing from JSON

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Change Log
 
 # Next Release
 Ensure that access to the constructor is available allowing private constructors to be used
+When `enableDefaultPrimitiveValues` is set, always treat primitives as though they have a default value
 
 # 0.2.0
 Allow use to optionally use default primitive values when missing from JSON

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Change Log
 ==========
 
+# Next Release
+
 # 0.2.0
 Allow use to optionally use default primitive values when missing from JSON
 

--- a/library/src/main/kotlin/com/livefront/gsonkotlinadapter/KoltinReflectiveTypeAdapterFactory.kt
+++ b/library/src/main/kotlin/com/livefront/gsonkotlinadapter/KoltinReflectiveTypeAdapterFactory.kt
@@ -16,6 +16,7 @@ import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
 import kotlin.reflect.KParameter
 import kotlin.reflect.full.primaryConstructor
+import kotlin.reflect.jvm.isAccessible
 import kotlin.reflect.jvm.javaConstructor
 
 /**
@@ -51,7 +52,10 @@ class KotlinReflectiveTypeAdapterFactory private constructor(
         kClass: KClass<T>,
         private val enableDefaultPrimitiveValues: Boolean
     ) : TypeAdapter<T>() {
-        private val primaryConstructor: KFunction<T> = kClass.primaryConstructor!!
+        private val primaryConstructor: KFunction<T> = kClass
+            .primaryConstructor!!
+            .apply { isAccessible = true }
+
         private val declaringClass: Class<T> = primaryConstructor.javaConstructor?.declaringClass!!
 
         /**

--- a/library/src/main/kotlin/com/livefront/gsonkotlinadapter/KoltinReflectiveTypeAdapterFactory.kt
+++ b/library/src/main/kotlin/com/livefront/gsonkotlinadapter/KoltinReflectiveTypeAdapterFactory.kt
@@ -92,8 +92,9 @@ class KotlinReflectiveTypeAdapterFactory private constructor(
             .toMap()
 
         private val delegateAdapter: TypeAdapter<T> = gson.getDelegateAdapter(factory, type)
-        private val innerAdapters: Map<KParameter, TypeAdapter<*>> = primaryConstructor
-            .parameters
+        private val innerAdapters: Map<KParameter, TypeAdapter<*>> = constructorParameterNameMap
+            .filterNot { (_, names) -> names.isEmpty() }
+            .keys
             .associateWith { gson.getAdapter(type.resolveParameterType(it)) }
 
         override fun write(writer: JsonWriter, value: T?) {

--- a/library/src/main/kotlin/com/livefront/gsonkotlinadapter/KoltinReflectiveTypeAdapterFactory.kt
+++ b/library/src/main/kotlin/com/livefront/gsonkotlinadapter/KoltinReflectiveTypeAdapterFactory.kt
@@ -10,6 +10,7 @@ import com.google.gson.stream.JsonToken
 import com.google.gson.stream.JsonWriter
 import com.livefront.gsonkotlinadapter.util.defaultValue
 import com.livefront.gsonkotlinadapter.util.getSerializedNames
+import com.livefront.gsonkotlinadapter.util.isPrimitive
 import com.livefront.gsonkotlinadapter.util.resolveParameterType
 import com.livefront.gsonkotlinadapter.util.toKClass
 import kotlin.reflect.KClass
@@ -75,10 +76,15 @@ class KotlinReflectiveTypeAdapterFactory private constructor(
             .map { it to it.getSerializedNames(declaringClass) }
             .toMap()
 
-        private val invalidReadParameters: List<KParameter> = constructorParameterNameMap
-            .entries
-            .filter { (parameter, names) -> names.isEmpty() && !parameter.isOptional }
-            .map { it.key }
+        private val invalidReadParameters: Set<KParameter> = constructorParameterNameMap
+            .filter { (parameter, names) ->
+                if (enableDefaultPrimitiveValues && parameter.isPrimitive) {
+                    false
+                } else {
+                    names.isEmpty() && !parameter.isOptional
+                }
+            }
+            .keys
 
         private val constructorMap: Map<String, KParameter> = constructorParameterNameMap
             .entries

--- a/library/src/main/kotlin/com/livefront/gsonkotlinadapter/util/KParameter.kt
+++ b/library/src/main/kotlin/com/livefront/gsonkotlinadapter/util/KParameter.kt
@@ -30,6 +30,22 @@ internal val KParameter.defaultValue: Any?
     }
 
 /**
+ * Returns the `true` if this [KParameter] is a primitive, `false` otherwise.
+ */
+internal val KParameter.isPrimitive: Boolean
+    get() = when (type.classifier as? KClass<*>) {
+        Boolean::class,
+        Byte::class,
+        Char::class,
+        Double::class,
+        Float::class,
+        Integer::class,
+        Long::class,
+        Short::class -> true
+        else -> false
+    }
+
+/**
  * Retrieves all possible names for the [KParameter] based on the name of the property, the
  * [SerializedName] annotation, and whether it's [Transient] or not.
  */


### PR DESCRIPTION
This MR addresses a couple of bugs in the adapter:

* Ensure that access to the constructor is available allowing private constructors to be used.
* When `enableDefaultPrimitiveValues` is set, always treat primitives as though they have a default value.
* Only fetch the delegate adapter when the property is going to be serialized/deserialized. (ignore transient parameters)
* Move checks for `isSealed` and `isAbstract` from `create` method to `read` since Gson will still serialize the data, even if we cannot deserialize it.