### PR TITLE
Add empty 'buildscript' block to Appease Java 10 CI.

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -6,6 +6,10 @@ archivesBaseName = 'gson-kotlin-adapter'
 group = "com.livefront.gsonkotlinadapter"
 version = "0.2.0"
 
+buildscript {
+    // Just need to define this
+}
+
 dependencies {
     compileOnly "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compileOnly "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"


### PR DESCRIPTION
CI has been struggling to pass post-merge due to failures with Java 10. Adding this empty `buildscript` block _should_ address the issue.

```
build file '/home/runner/work/gson-kotlin-adapter/gson-kotlin-adapter/build.gradle': 3: Can't have an abstract method in a non-abstract class. The class '_BuildScript_' must be declared abstract or the method 'org.gradle.api.file.ConfigurableFileCollection files(java.lang.Object[])' must be implemented.
   @ line 3, column 1.
     buildscript {
     ^
```