### PR TITLE
Remove Java versions to CI matrix.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,19 +15,12 @@ jobs:
       fail-fast: false
       matrix:
         java-version:
-          - 1.8
-          - 9
-          - 10
+          - 8
           - 11
-          - 12
-          - 13
-          - 14
-          - 15
-          # - 16 TODO: Include JDK 16 when kapt supports it: https://youtrack.jetbrains.com/issue/KT-45545
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v1
@@ -38,7 +31,7 @@ jobs:
           rm -fr ~/.gradle/caches/*/plugin-resolution/
 
       - name: Cache Gradle Files
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path:  |
             ~/.gradle/caches
@@ -54,8 +47,9 @@ jobs:
           bundler-cache: true
 
       - name: Configure JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
+          distribution: 'zulu'
           java-version: ${{ matrix.java-version }}
 
       - name: Test


### PR DESCRIPTION
This PR updates the `ci.yml` file to use fewer Java versions and updates the versions of the GitHub Actions we use.