### PR TITLE
Dependencies update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
         java-version:
           - 8
           - 11
+          - 17
 
     steps:
       - name: Checkout

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -7,5 +7,5 @@ repositories {
 }
 
 dependencies {
-    implementation(kotlin(module = "gradle-plugin", version = "1.7.10"))
+    implementation(kotlin(module = "gradle-plugin", version = "1.8.21"))
 }

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,6 +1,6 @@
 object Versions {
     object Google {
-        const val gson = "2.8.9"
+        const val gson = "2.10.1"
     }
 
     object JetBrains {

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -6,14 +6,14 @@ object Versions {
     object JetBrains {
         // This needs to be kept in sync with the build.gradle.kts file for 'buildSrc'.
         const val kotlin = "1.8.21"
-        const val kover = "0.6.1"
+        const val kover = "0.7.1"
     }
 
     object Junit {
-        const val jupiter = "5.9.1"
+        const val jupiter = "5.9.3"
     }
 
     object Mockk {
-        const val mockk = "1.13.3"
+        const val mockk = "1.13.5"
     }
 }

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -5,7 +5,7 @@ object Versions {
 
     object JetBrains {
         // This needs to be kept in sync with the build.gradle.kts file for 'buildSrc'.
-        const val kotlin = "1.7.10"
+        const val kotlin = "1.8.21"
         const val kover = "0.6.1"
     }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-all.zip

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -14,9 +14,9 @@ base {
 }
 
 dependencies {
-    compileOnly(kotlin(module = "stdlib", version = Versions.JetBrains.kotlin))
-    compileOnly(kotlin(module = "reflect", version = Versions.JetBrains.kotlin))
-    compileOnly("com.google.code.gson:gson:${Versions.Google.gson}")
+    implementation(kotlin(module = "stdlib", version = Versions.JetBrains.kotlin))
+    implementation(kotlin(module = "reflect", version = Versions.JetBrains.kotlin))
+    implementation("com.google.code.gson:gson:${Versions.Google.gson}")
 
     testImplementation("com.google.code.gson:gson:${Versions.Google.gson}")
     testImplementation("org.junit.jupiter:junit-jupiter:${Versions.Junit.jupiter}")

--- a/library/src/test/kotlin/com/livefront/gsonkotlinadapter/KotlinReflectiveTypeAdapterFactoryTests.kt
+++ b/library/src/test/kotlin/com/livefront/gsonkotlinadapter/KotlinReflectiveTypeAdapterFactoryTests.kt
@@ -33,7 +33,7 @@ class KotlinReflectiveTypeAdapterFactoryTests {
     @AfterEach
     fun teardown() {
         verify(exactly = 0) {
-            anyConstructed<ReflectiveTypeAdapterFactory.Adapter<*>>().read(any())
+            anyConstructed<ReflectiveTypeAdapterFactory.Adapter<*, *>>().read(any())
         }
         unmockkAll()
     }


### PR DESCRIPTION
This PR updates all of the library dependencies and explicitly imports those dependencies with `implementation` instead of `compileOnly`.

* [Gradle](https://gradle.org/releases/)
* [Kotlin](https://github.com/JetBrains/kotlin/releases/tag/v1.8.21)
* [Gson](https://github.com/google/gson/releases)
* [MockK](https://github.com/mockk/mockk/releases)
* [Junit Jupiter](https://junit.org/junit5/docs/5.9.3/release-notes/)
* [Kover](https://github.com/Kotlin/kotlinx-kover/releases)
