### PR TITLE
Singleton objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ When calling `create`, an optional `enableDefaultPrimitiveValues` parameter is a
 | Long           | 0L            |
 | Short          | 0             |
 
+Deserializing any Kotlin singletons denoted by the `object` keyword will return the correct singleton instance. A singleton object is always serialized as an empty JSON structure (`{}`).
+
 <a name="how-it-works"></a>
 ## How It Works
 The `Gson Kotlin Adapter` operates on all Kotlin classes and allows Gson's default adapter to handle the rest. The actual functionality for Kotlin classes depends on whether you are reading or writing. All non-Kotlin classes will be ignored by the `Gson Kotlin Adapter`.

--- a/library/src/main/kotlin/com/livefront/gsonkotlinadapter/KoltinReflectiveTypeAdapterFactory.kt
+++ b/library/src/main/kotlin/com/livefront/gsonkotlinadapter/KoltinReflectiveTypeAdapterFactory.kt
@@ -87,7 +87,7 @@ class KotlinReflectiveTypeAdapterFactory private constructor(
         )
     }
 
-    internal class Adapter<T : Any>(
+    private class Adapter<T : Any>(
         private val delegateAdapter: TypeAdapter<T>,
         private val innerAdapters: Map<KParameter, TypeAdapter<*>>,
         private val kClass: KClass<T>,

--- a/library/src/main/kotlin/com/livefront/gsonkotlinadapter/KoltinReflectiveTypeAdapterFactory.kt
+++ b/library/src/main/kotlin/com/livefront/gsonkotlinadapter/KoltinReflectiveTypeAdapterFactory.kt
@@ -45,7 +45,7 @@ class KotlinReflectiveTypeAdapterFactory private constructor(
             .primaryConstructor
             ?.apply { isAccessible = true }
             ?: return null
-        val declaringClass: Class<T> = primaryConstructor.javaConstructor!!.declaringClass
+        val declaringClass: Class<T> = requireNotNull(primaryConstructor.javaConstructor).declaringClass
         val innerAdapters: MutableMap<KParameter, TypeAdapter<*>> = mutableMapOf()
         val constructorParameterDefaultsMap: MutableMap<KParameter, Any?> = mutableMapOf()
         val invalidReadParameters: MutableSet<KParameter> = mutableSetOf()

--- a/library/src/test/kotlin/com/livefront/gsonkotlinadapter/KotlinReflectiveTypeAdapterFactoryClasses.kt
+++ b/library/src/test/kotlin/com/livefront/gsonkotlinadapter/KotlinReflectiveTypeAdapterFactoryClasses.kt
@@ -81,6 +81,8 @@ data class SerializableNameData(
     @SerializedName("gone") val missingString: String?
 )
 
+object SingletonData
+
 data class StringData(
     val nonnullString: String,
     val nullableString1: String?,

--- a/library/src/test/kotlin/com/livefront/gsonkotlinadapter/KotlinReflectiveTypeAdapterFactoryTests.kt
+++ b/library/src/test/kotlin/com/livefront/gsonkotlinadapter/KotlinReflectiveTypeAdapterFactoryTests.kt
@@ -39,6 +39,24 @@ class KotlinReflectiveTypeAdapterFactoryTests {
     }
 
     @Test
+    fun fromJson_singletonData() {
+        // Should deserialize the JSON to a SingletonData object and make sure it
+        // matches the pre-constructed data.
+        val expectedData = SingletonData
+        val actualData = gson.fromJson<SingletonData>("""{}""")
+        assertEquals(expectedData, actualData)
+    }
+
+    @Test
+    fun toJson_singletonData() {
+        // Should serialize the SingletonData object to JSON and make sure it
+        // matches the pre-defined data.
+        val expectedJson = """{}"""
+        val actualJson = gson.toJson(SingletonData)
+        assertEquals(expectedJson, actualJson)
+    }
+
+    @Test
     fun fromJson_booleanData() {
         // Should deserialize the JSON to a BooleanData object and make sure it
         // matches the pre-constructed data.


### PR DESCRIPTION
This PR adds proper support for Kotlin Singleton `objects`.

Previously, these objects would be serialized to new instances of the object, with this new functionality, it will always return the correct single instance.