### PR TITLE
updated the gson version to from 2.10.1 to 2.13.2

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -7,7 +7,7 @@ object Versions {
     }
 
     object Google {
-        const val gson = "2.10.1"
+        const val gson = "2.13.2"
         const val hilt = "2.47"
     }
 

--- a/library/src/main/kotlin/com/livefront/gsonkotlinadapter/util/TypeToken.kt
+++ b/library/src/main/kotlin/com/livefront/gsonkotlinadapter/util/TypeToken.kt
@@ -1,6 +1,6 @@
 package com.livefront.gsonkotlinadapter.util
 
-import com.google.gson.internal.`$Gson$Types`
+import com.google.gson.internal.GsonTypes
 import com.google.gson.reflect.TypeToken
 import kotlin.reflect.KClass
 import kotlin.reflect.KParameter
@@ -21,4 +21,4 @@ internal fun <T : Any> TypeToken<T>.toKClass(): KClass<T> =
  */
 internal fun TypeToken<*>.resolveParameterType(
     property: KParameter,
-): TypeToken<*> = TypeToken.get(`$Gson$Types`.resolve(type, rawType, property.type.javaType))
+): TypeToken<*> = TypeToken.get(GsonTypes.resolve(type, rawType, property.type.javaType))


### PR DESCRIPTION
When using the newest Gson version, the GsonTypes was renamed. Due to this a class not found exception is thrown. This updated the Gson Dependency.